### PR TITLE
Fix broken BrowscapServiceProvider when used with Lumen

### DIFF
--- a/src/BrowscapServiceProvider.php
+++ b/src/BrowscapServiceProvider.php
@@ -7,7 +7,7 @@ namespace Propa\BrowscapPHP;
 use BrowscapPHP\Browscap;
 use BrowscapPHP\BrowscapInterface;
 use Doctrine\Common\Cache\FilesystemCache;
-use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
@@ -38,7 +38,7 @@ class BrowscapServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->singleton('browscap', function (ApplicationContract $app) {
+        $this->app->singleton('browscap', function (ContainerContract $app) {
             $cache = new SimpleCacheAdapter(
                 new FilesystemCache(config('browscap.cache'))
             );


### PR DESCRIPTION
BrowscapServiceProvider was broken when used with Lumen because Laravel\Lumen\Application does not implement Illuminate\Contracts\Foundation\Application.

However, both Laravel\Lumen\Application (Lumen) and Illuminate\Foundation\Application (Laravel) extend Illuminate\Container\Container which implements Illuminate\Contracts\Container\Container

Replace

```php
use Illuminate\Contracts\Foundation\Application as ApplicationContract;	
```

with

```php
use Illuminate\Contracts\Container\Container as ContainerContract;
```

