### PR TITLE
Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "php": "^7.1.0|^8.0",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0",
-        "browscap/browscap-php": "^4.0|^5.0"
+        "php": "^7.1.0 || ^8.0",
+        "illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "browscap/browscap-php": "^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.1.0 || ^8.0",
         "illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "browscap/browscap-php": "^4.0 || ^5.0"
+        "browscap/browscap-php": "^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "propa/laravel-browscap",
-    "description": "Browscap-PHP integration for Laravel 5/6",
+    "description": "Browscap-PHP integration for Laravel 5-9",
     "keywords": ["laravel", "browscap", "browscap-php", "user-agent", "browser"],
     "license": "MIT",
     "authors": [
@@ -12,7 +12,8 @@
     "require": {
         "php": "^7.1.0 || ^8.0",
         "illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "browscap/browscap-php": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+        "browscap/browscap-php": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "roave/doctrine-simplecache": "^2.2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Added support for laravel ^9. I had to allow a newer version of browscap as well to support Symfony 6 and as they removed roave/doctrine-simplecache, it must be added to this package as it depends on it. Anyway, It's better to mention required packages explicitly.