### PR TITLE
Browscap-PHP has changed internal cache implementation with 6.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     "require": {
         "php": "^7.1.0 || ^8.0",
         "illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "browscap/browscap-php": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-        "roave/doctrine-simplecache": "^2.2.0"
+        "browscap/browscap-php": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/BrowscapServiceProvider.php
+++ b/src/BrowscapServiceProvider.php
@@ -6,13 +6,15 @@ namespace Propa\BrowscapPHP;
 
 use BrowscapPHP\Browscap;
 use BrowscapPHP\BrowscapInterface;
-use Doctrine\Common\Cache\FilesystemCache;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Foundation\Application as LaravelApplication;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
-use Roave\DoctrineSimpleCache\SimpleCacheAdapter;
-use WurflCache\Adapter\File;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use MatthiasMullie\Scrapbook\Adapters\Flysystem;
+use MatthiasMullie\Scrapbook\Psr16\SimpleCache;
 
 /**
  * Browscap service provider
@@ -39,9 +41,12 @@ class BrowscapServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton('browscap', function (ContainerContract $app) {
-            $cache = new SimpleCacheAdapter(
-                new FilesystemCache(config('browscap.cache'))
+            $adapter    = new LocalFilesystemAdapter(Config::get('browscap.cache'));
+            $filesystem = new Filesystem($adapter);
+            $cache      = new SimpleCache(
+                new Flysystem($filesystem)
             );
+
             $bc = new Browscap(
                 $cache,
                 $app->make('log')


### PR DESCRIPTION
The current version 2.0.10 of the package is broken if using browscap-php >= 6 as they have more or less silently changed the internally used caching implementation for the console commands. The previous pr just required roave/doctrine-simplecache but this causes the command used cache to be different from the cache used within this package.

This pr updates the codebase to be compatible with browscap-php >= 6 but drops support for versions below 6. Do you have any ideas/wishes to change it or are you ok with this change? Maybe the package version should be 3.0 as this is a breaking change in regards of semver? And maybe there should be a new release 2.0.11 that fixes the issues caused by the previous pr.